### PR TITLE
Better exception case

### DIFF
--- a/rest_framework_json_schema/renderers.py
+++ b/rest_framework_json_schema/renderers.py
@@ -1,4 +1,7 @@
 from collections import OrderedDict
+from django.core.exceptions import ImproperlyConfigured
+import six
+import sys
 
 from rest_framework.renderers import JSONRenderer
 
@@ -48,7 +51,15 @@ class JSONAPIRenderer(JSONRenderer):
         """
         Override this if you have a different way to get the schema.
         """
-        serializer = data.serializer
+        try:
+            serializer = data.serializer
+        except AttributeError:
+            six.reraise(ImproperlyConfigured,
+                        ImproperlyConfigured(
+                            "Serializer not found on data to render. This usually happens when a ViewSet doesn't have a JSONAPI paginator."
+                        ),
+                        sys.exc_info()[2])
+
         if not getattr(serializer, 'many', False):
             return getattr(serializer, 'schema')
         else:

--- a/rest_framework_json_schema/test_support/urls.py
+++ b/rest_framework_json_schema/test_support/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url, include
 from rest_framework import routers
-from .views import ArtistViewSet, AlbumViewSet, TrackViewSet, PaginateViewSet
+from .views import (ArtistViewSet, AlbumViewSet, TrackViewSet, PaginateViewSet, NonJSONPaginateViewSet)
 
 
 router = routers.DefaultRouter()
@@ -8,6 +8,7 @@ router.register(r'artist', ArtistViewSet, 'artist')
 router.register(r'album', AlbumViewSet, 'album')
 router.register(r'track', TrackViewSet, 'track')
 router.register(r'paged', PaginateViewSet, 'page')
+router.register(r'paged-nonjson', NonJSONPaginateViewSet, 'page-nonjson')
 
 urlpatterns = [
     url(r'^api/', include(router.urls))

--- a/rest_framework_json_schema/test_support/views.py
+++ b/rest_framework_json_schema/test_support/views.py
@@ -1,6 +1,7 @@
 from django.http import Http404
 from rest_framework import viewsets
 from rest_framework.decorators import detail_route
+from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
@@ -48,6 +49,13 @@ class ArtistViewSet(BaseViewSet):
 
 class PaginateViewSet(ArtistViewSet):
     pagination_class = JSONAPILimitOffsetPagination
+
+
+class NonJSONPaginateViewSet(ArtistViewSet):
+    """
+    Tests when a viewset is paginated but without a JSONAPI Paginator
+    """
+    pagination_class = LimitOffsetPagination
 
 
 class AlbumViewSet(BaseViewSet):

--- a/rest_framework_json_schema/tests/test_pagination.py
+++ b/rest_framework_json_schema/tests/test_pagination.py
@@ -1,10 +1,11 @@
+from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.test import override_settings
 
 from rest_framework.test import APISimpleTestCase, APIRequestFactory
 
 from rest_framework_json_schema.test_support.serializers import reset_data
-from rest_framework_json_schema.test_support.views import PaginateViewSet
+from rest_framework_json_schema.test_support.views import PaginateViewSet, NonJSONPaginateViewSet
 
 
 @override_settings(ROOT_URLCONF='rest_framework_json_schema.test_support.urls')
@@ -48,3 +49,21 @@ class JSONAPIPaginationTestCase(APISimpleTestCase):
                 }
             ]
         })
+
+
+@override_settings(ROOT_URLCONF='rest_framework_json_schema.test_support.urls')
+class JSONAPINonPageTestCase(APISimpleTestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.view_list = NonJSONPaginateViewSet.as_view({'get': 'list'})
+        self.view_detail = NonJSONPaginateViewSet.as_view({'get': 'retrieve'})
+        reset_data()
+
+    def test_limit_offset(self):
+        list_url = reverse('page-list')
+        request = self.factory.get(list_url, {'offset': 2, 'limit': 2})
+        response = self.view_list(request)
+        with self.assertRaises(ImproperlyConfigured):
+            response.render()

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {py27,py34,py35}-django18-drf{35}
-    {py27,py34,py35,py36}-{django19,django110,django111}-drf{35}
+    {py27,py34,py35}-django18-drf{35,36}
+    {py27,py34,py35,py36}-{django19,django110,django111}-drf{35,36}
 
 [testenv]
 deps =
@@ -9,6 +9,7 @@ deps =
     django18: django>=1.8.0,<1.9.0
     django19: django>=1.9.0,<1.10.0
     django110: django>=1.10.0,<1.11.0
-    django111: django==1.11a1
+    django111: django==1.11rc1
     drf35: djangorestframework>=3.5.<3.6
+    drf36: djangorestframework>=3.6.<3.7
 commands = py.test --flake8


### PR DESCRIPTION
Make it more clear what needs to be done when the renderer can’t find a serializer in the data.