### PR TITLE
Crashes and deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - DJANGO='django>=1.8.0,<1.9.0' DRF='djangorestframework>=3.5'
   - DJANGO='django>=1.9.0,<1.10.0' DRF='djangorestframework>=3.5'
   - DJANGO='django>=1.10.0,<1.11.0' DRF='djangorestframework>=3.5'
-  - DJANGO='django==1.11a1' DRF='djangorestframework>=3.5'
+  - DJANGO='django>=1.11.0,<1.12.0' DRF='djangorestframework>=3.5'
 before_install:
   - pip install -U pytest
   - pip install -r requirements-test.txt
@@ -23,7 +23,6 @@ matrix:
     - python: "3.6"
       env: DJANGO='django>=1.8.0,<1.9.0' DRF='djangorestframework>=3.5'
   allow_failures:
-    - env: DJANGO='django==1.11a1'
     - env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/rest_framework_json_schema/compat.py
+++ b/rest_framework_json_schema/compat.py
@@ -1,0 +1,4 @@
+try:
+    from django.urls import reverse  # noqa
+except ImportError:
+    from django.core.urlresolvers import reverse  # noqa

--- a/rest_framework_json_schema/exceptions.py
+++ b/rest_framework_json_schema/exceptions.py
@@ -10,3 +10,9 @@ class IncludeInvalid(Exception):
     """
     This relationship cannot be included.
     """
+
+
+class NoSchema(Exception):
+    """
+    Schema not found on the data to render.
+    """

--- a/rest_framework_json_schema/renderers.py
+++ b/rest_framework_json_schema/renderers.py
@@ -56,7 +56,8 @@ class JSONAPIRenderer(JSONRenderer):
         except AttributeError:
             six.reraise(ImproperlyConfigured,
                         ImproperlyConfigured(
-                            "Serializer not found on data to render. This usually happens when a ViewSet doesn't have a JSONAPI paginator."
+                            "Serializer not found on data to render. "
+                            "This usually happens when a ViewSet doesn't have a JSONAPI paginator."
                         ),
                         sys.exc_info()[2])
 

--- a/rest_framework_json_schema/renderers.py
+++ b/rest_framework_json_schema/renderers.py
@@ -1,10 +1,8 @@
 from collections import OrderedDict
-from django.core.exceptions import ImproperlyConfigured
-import six
-import sys
 
 from rest_framework.renderers import JSONRenderer
 
+from .exceptions import NoSchema
 from .utils import parse_include
 
 
@@ -54,12 +52,7 @@ class JSONAPIRenderer(JSONRenderer):
         try:
             serializer = data.serializer
         except AttributeError:
-            six.reraise(ImproperlyConfigured,
-                        ImproperlyConfigured(
-                            "Serializer not found on data to render. "
-                            "This usually happens when a ViewSet doesn't have a JSONAPI paginator."
-                        ),
-                        sys.exc_info()[2])
+            raise NoSchema()
 
         if not getattr(serializer, 'many', False):
             return getattr(serializer, 'schema')
@@ -91,11 +84,16 @@ class JSONAPIRenderer(JSONRenderer):
         if self.is_exception(data, renderer_context):
             rendered['errors'] = self.render_exception(data, renderer_context)
         else:
-            rendered_data, included = self.render_data(data, renderer_context, to_include)
-            if rendered_data is not None:
-                rendered['data'] = rendered_data
-            if included:
-                rendered['included'] = included
+            try:
+                rendered_data, included = self.render_data(data, renderer_context, to_include)
+                if rendered_data is not None:
+                    rendered['data'] = rendered_data
+                if included:
+                    rendered['included'] = included
+            except NoSchema:
+                # Because we don't know the type of this data, we can't include it as
+                # primary data.
+                meta['data'] = data
 
         data_meta = getattr(data, 'meta', None)
         if data_meta:

--- a/rest_framework_json_schema/schema.py
+++ b/rest_framework_json_schema/schema.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
-from django.core.urlresolvers import reverse
 
+from .compat import reverse
 from .exceptions import TypeConflict, IncludeInvalid
 from .transforms import NullTransform
 

--- a/rest_framework_json_schema/test_support/serializers.py
+++ b/rest_framework_json_schema/test_support/serializers.py
@@ -135,8 +135,9 @@ class TrackSerializer(serializers.Serializer):
     id = serializers.CharField(required=False)
     track_num = serializers.IntegerField()
     name = serializers.CharField()
-    album = JSONAPIRelationshipField(serializer='rest_framework_json_schema.test_support.serializers.AlbumSerializer',
-                                     queryset=get_albums)
+    album = JSONAPIRelationshipField(
+        serializer='rest_framework_json_schema.test_support.serializers.AlbumSerializer',
+        queryset=get_albums)
 
     schema = TrackObject
 

--- a/rest_framework_json_schema/test_support/urls.py
+++ b/rest_framework_json_schema/test_support/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url, include
 from rest_framework import routers
-from .views import (ArtistViewSet, AlbumViewSet, TrackViewSet, PaginateViewSet, NonJSONPaginateViewSet)
+from .views import (ArtistViewSet, AlbumViewSet, TrackViewSet,
+                    PaginateViewSet, NonJSONPaginateViewSet)
 
 
 router = routers.DefaultRouter()

--- a/rest_framework_json_schema/test_support/views.py
+++ b/rest_framework_json_schema/test_support/views.py
@@ -5,7 +5,8 @@ from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
-from .serializers import ArtistSerializer, AlbumSerializer, TrackSerializer, get_artists, get_albums, get_tracks
+from .serializers import (ArtistSerializer, AlbumSerializer, TrackSerializer,
+                          get_artists, get_albums, get_tracks)
 from rest_framework_json_schema.filters import get_query_filters
 from rest_framework_json_schema.negotiation import JSONAPIContentNegotiation
 from rest_framework_json_schema.pagination import JSONAPILimitOffsetPagination

--- a/rest_framework_json_schema/tests/test_negotiation.py
+++ b/rest_framework_json_schema/tests/test_negotiation.py
@@ -21,7 +21,8 @@ class JSONAPINegotiationTestCase(APISimpleTestCase):
         accept_list = negotiator.get_accept_list(request)
         self.assertEqual(accept_list, ['application/vnd.api+json'])
 
-        request = factory.get(reverse('artist-list'), HTTP_ACCEPT='text/html,application/vnd.api+json;indent=4,application/xml;q=0.9,*/*;q=0.8')
+        accept = 'text/html,application/vnd.api+json;indent=4,application/xml;q=0.9,*/*;q=0.8'
+        request = factory.get(reverse('artist-list'), HTTP_ACCEPT=accept)
         accept_list = negotiator.get_accept_list(request)
         self.assertEqual(accept_list, ['text/html', 'application/xml;q=0.9', '*/*;q=0.8'])
 
@@ -34,12 +35,14 @@ class JSONAPINegotiationTestCase(APISimpleTestCase):
         factory = APIRequestFactory()
         view_list = ArtistViewSet.as_view({'get': 'list'})
 
-        request = factory.get(reverse('artist-list'), HTTP_ACCEPT='application/vnd.api+json')
+        request = factory.get(reverse('artist-list'),
+                              HTTP_ACCEPT='application/vnd.api+json')
         response = view_list(request)
         # Acceptable
         self.assertEqual(response.status_code, 200)
 
-        request = factory.get(reverse('artist-list'), HTTP_ACCEPT='application/vnd.api+json; indent=4')
+        request = factory.get(reverse('artist-list'),
+                              HTTP_ACCEPT='application/vnd.api+json; indent=4')
         response = view_list(request)
         self.assertEqual(response.status_code, 406)
         self.assertEqual(response.data, {

--- a/rest_framework_json_schema/tests/test_pagination.py
+++ b/rest_framework_json_schema/tests/test_pagination.py
@@ -1,7 +1,7 @@
-from django.core.exceptions import ImproperlyConfigured
+import json
+
 from django.core.urlresolvers import reverse
 from django.test import override_settings
-
 from rest_framework.test import APISimpleTestCase, APIRequestFactory
 
 from rest_framework_json_schema.test_support.serializers import reset_data
@@ -65,5 +65,10 @@ class JSONAPINonPageTestCase(APISimpleTestCase):
         list_url = reverse('page-list')
         request = self.factory.get(list_url, {'offset': 2, 'limit': 2})
         response = self.view_list(request)
-        with self.assertRaises(ImproperlyConfigured):
-            response.render()
+        response.render()
+        # This really is misconfigured, it's mostly when someone has forgotten
+        # to add a JSONAPI paginator to the View.
+        self.assertEqual(response['Content-Type'], 'application/vnd.api+json')
+        data = json.loads(response.content.decode())
+        self.assertIn('meta', data)
+        self.assertIn('data', data['meta'])

--- a/rest_framework_json_schema/tests/test_renderers.py
+++ b/rest_framework_json_schema/tests/test_renderers.py
@@ -90,6 +90,22 @@ class JSONAPIAttributesRendererTestCase(APISimpleTestCase):
             ]
         })
 
+    def test_options(self):
+        request = self.factory.options(reverse('artist-list'))
+        response = self.view_list(request)
+        response.render()
+        self.assertEqual(response['Content-Type'], 'application/vnd.api+json')
+        self.assertJSONEqual(response.content.decode(), {
+            'meta': {
+                'data': {
+                    'description': 'A simple ViewSet for listing or retrieving artists.',
+                    'name': 'Artist',
+                    'parses': ['application/vnd.api+json'],
+                    'renders': ['application/vnd.api+json']
+                }
+            }
+        })
+
 
 @override_settings(ROOT_URLCONF='rest_framework_json_schema.test_support.urls')
 class JSONAPIRelationshipsRendererTestCase(APISimpleTestCase):

--- a/rest_framework_json_schema/tests/test_schema.py
+++ b/rest_framework_json_schema/tests/test_schema.py
@@ -4,7 +4,8 @@ from django.test import SimpleTestCase, override_settings
 from rest_framework.test import APIRequestFactory
 
 from rest_framework_json_schema.exceptions import TypeConflict, IncludeInvalid
-from rest_framework_json_schema.schema import ResourceObject, RelationshipObject, ResourceIdObject, LinkObject, UrlLink
+from rest_framework_json_schema.schema import (ResourceObject, RelationshipObject,
+                                               ResourceIdObject, LinkObject, UrlLink)
 from rest_framework_json_schema.transforms import CamelCaseTransform
 from rest_framework_json_schema.utils import parse_include
 
@@ -81,8 +82,11 @@ class ResourceObjectTest(SimpleTestCase):
         class TestObject(ResourceObject):
             type = 'artists'
             links = (
-                ('self', UrlLink(view_name='artist-detail', url_kwargs={'pk': 'id'})),
-                ('relative', UrlLink(view_name='artist-detail', url_kwargs={'pk': 'id'}, absolute=False)),
+                ('self', UrlLink(view_name='artist-detail',
+                                 url_kwargs={'pk': 'id'})),
+                ('relative', UrlLink(view_name='artist-detail',
+                                     url_kwargs={'pk': 'id'},
+                                     absolute=False)),
                 ('object', ObjectLink())
             )
 
@@ -186,7 +190,8 @@ class ResourceObjectTest(SimpleTestCase):
     def test_render_complex_relationship(self):
         """
         Allow specifying a relationship object that specifies additional data for the relationship.
-        Relationship links will most likely depend on some part of original object's data (like the pk)
+        Relationship links will most likely depend on some part of original object's data
+        (like the pk)
         """
         class ArtistRelationship(RelationshipObject):
             links = (

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,5 @@ license-file = LICENSE.txt
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = rest_framework_json_schema.dummy.settings
-flake8-ignore = E501
+flake8-max-line-length = 100
 flake8-max-complexity = 15

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     django18: django>=1.8.0,<1.9.0
     django19: django>=1.9.0,<1.10.0
     django110: django>=1.10.0,<1.11.0
-    django111: django==1.11rc1
+    django111: django==1.11.0,<1.12.0
     drf35: djangorestframework>=3.5.<3.6
     drf36: djangorestframework>=3.6.<3.7
 commands = py.test --flake8


### PR DESCRIPTION
1. Update to Django 1.11 release
2. Fix a deprecation including urls.include
3. Be more permissive when the renderer it passed data that isn't attached to a serializer.
