### PR TITLE
Fix included models and update support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ python:
   - "3.5"
   - "3.6"
 env:
-  - DJANGO='django>=1.8.0,<1.9.0' DRF='djangorestframework>=3.5'
-  - DJANGO='django>=1.9.0,<1.10.0' DRF='djangorestframework>=3.5'
-  - DJANGO='django>=1.10.0,<1.11.0' DRF='djangorestframework>=3.5'
-  - DJANGO='django>=1.11.0,<1.12.0' DRF='djangorestframework>=3.5'
+  - DJANGO='django>=1.10.0,<1.11.0' DRF='djangorestframework>=3.5,<3.6'
+  - DJANGO='django>=1.11.0,<1.12.0' DRF='djangorestframework>=3.5,<3.6'
+  - DJANGO='django>=1.10.0,<1.11.0' DRF='djangorestframework>=3.6,<3.7'
+  - DJANGO='django>=1.11.0,<1.12.0' DRF='djangorestframework>=3.6,<3.7'
 before_install:
   - pip install -U pytest
   - pip install -r requirements-test.txt
@@ -19,9 +19,6 @@ install:
 script:
   - py.test --flake8 --cov=./
 matrix:
-  exclude:
-    - python: "3.6"
-      env: DJANGO='django>=1.8.0,<1.9.0' DRF='djangorestframework>=3.5'
   allow_failures:
     - env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ specifically designed to be extensible and work with code that doesn't use ``Mod
 Tested with:
 
 * Python 2.7, 3.4, 3.5, 3.6
-* Django 1.8, 1.9, 1.10, 1.11
+* Django 1.10, 1.11
 * Django REST Framework: 3.5+
 
 Under active development.

--- a/rest_framework_json_schema/compat.py
+++ b/rest_framework_json_schema/compat.py
@@ -1,4 +1,0 @@
-try:
-    from django.urls import reverse  # noqa
-except ImportError:
-    from django.core.urlresolvers import reverse  # noqa

--- a/rest_framework_json_schema/relations.py
+++ b/rest_framework_json_schema/relations.py
@@ -31,6 +31,26 @@ class JSONAPIRelationshipField(serializers.PrimaryKeyRelatedField):
         )
         super(JSONAPIRelationshipField, self).__init__(**kwargs)
 
+    def use_pk_only_optimization(self):
+        # We can use the pk-only optimization if the parent's object
+        # is not included in the 'include' query parameter in some form.
+        request = self.context.get('request', None)
+        if not request:
+            # To be on the safe side -- this usually happens when we
+            # are in a multi-level include scenario.
+            return False
+
+        serializer = self.get_serializer()
+        if not serializer:
+            # If there's no serializer, there's no way to include this anyway
+            return True
+
+        include = request.query_params.get('include')
+        # Because we can't tell what "level" of inclusion we're at,
+        # the only safe thing we can do is to turn off the optimization
+        # if the include parameter exists.
+        return not include
+
     def get_serializer(self):
         if not self._serializer:
             # If the serializer value is a string, try to import it.

--- a/rest_framework_json_schema/relations.py
+++ b/rest_framework_json_schema/relations.py
@@ -40,11 +40,6 @@ class JSONAPIRelationshipField(serializers.PrimaryKeyRelatedField):
             # are in a multi-level include scenario.
             return False
 
-        serializer = self.get_serializer()
-        if not serializer:
-            # If there's no serializer, there's no way to include this anyway
-            return True
-
         include = request.query_params.get('include')
         # Because we can't tell what "level" of inclusion we're at,
         # the only safe thing we can do is to turn off the optimization

--- a/rest_framework_json_schema/schema.py
+++ b/rest_framework_json_schema/schema.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
-from .compat import reverse
+from django.urls import reverse
+
 from .exceptions import TypeConflict, IncludeInvalid
 from .transforms import NullTransform
 

--- a/rest_framework_json_schema/test_support/serializers.py
+++ b/rest_framework_json_schema/test_support/serializers.py
@@ -12,6 +12,16 @@ class BaseModel(object):
     def pk(self):
         return self.id
 
+    # This is used to fake a Django model for the purposes
+    # of RelatedField.use_pk_only_optimization. It just
+    # needs to return the ID value for foreign keys.
+    def serializable_value(self, field_name):
+        try:
+            value = getattr(self, field_name)
+            return value.id
+        except AttributeError:
+            return getattr(self, field_name)
+
 
 class Artist(BaseModel):
     def __init__(self, id, first_name, last_name):

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,12 @@
 [tox]
 envlist =
-    {py27,py34,py35}-django18-drf{35,36}
-    {py27,py34,py35,py36}-{django19,django110,django111}-drf{35,36}
+    {py27,py34,py35,py36}-{django110,django111}-drf{35,36}
 
 [testenv]
 deps =
     -rrequirements-test.txt
-    django18: django>=1.8.0,<1.9.0
-    django19: django>=1.9.0,<1.10.0
     django110: django>=1.10.0,<1.11.0
-    django111: django==1.11.0,<1.12.0
+    django111: django>=1.11.0,<1.12.0
     drf35: djangorestframework>=3.5.<3.6
     drf36: djangorestframework>=3.6.<3.7
 commands = py.test --flake8


### PR DESCRIPTION
Don’t enable the “pk-only” optimization if there is an include parameter.

Drop support for Django 1.8 and 1.9: These have reached the end of their extended support.
Add explicit support for DRF 3.5, 3.6 in Travis.