### PR TITLE
Sparse fieldsets

### DIFF
--- a/rest_framework_json_schema/parsers.py
+++ b/rest_framework_json_schema/parsers.py
@@ -4,6 +4,7 @@ from rest_framework.parsers import JSONParser
 
 from .exceptions import TypeConflict
 from .renderers import JSONAPIRenderer
+from .schema import Context
 
 
 class Conflict(exceptions.APIException):
@@ -31,7 +32,7 @@ class JSONAPIParser(JSONParser):
             raise exceptions.ValidationError('No primary data.')
 
         try:
-            parsed = schema().parse(data, parser_context.get('request', None))
+            parsed = schema().parse(data, Context(parser_context.get('request', None)))
         except TypeConflict as e:
             raise Conflict(str(e))
 

--- a/rest_framework_json_schema/renderers.py
+++ b/rest_framework_json_schema/renderers.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 
 from rest_framework.renderers import JSONRenderer
 
+from .schema import Context
 from .exceptions import NoSchema
 from .utils import parse_include
 
@@ -14,7 +15,8 @@ class JSONAPIRenderer(JSONRenderer):
     jsonapi = None
 
     def render_obj(self, obj, schema, renderer_context, include):
-        return schema.render(obj, renderer_context.get('request', None), include, {})
+        context = Context(renderer_context.get('request', None), include, {})
+        return schema.render(obj, context)
 
     def render_list(self, obj_list, schema, renderer_context, include):
         primary = []

--- a/rest_framework_json_schema/renderers.py
+++ b/rest_framework_json_schema/renderers.py
@@ -9,7 +9,7 @@ from .exceptions import NoSchema
 from .utils import parse_include
 
 
-RX_FIELDS = re.compile(r'fields\[([a-zA-Z0-9\-_]+)\]')
+RX_FIELDS = re.compile(r'^fields\[([a-zA-Z0-9\-_]+)\]$')
 
 
 class JSONAPIRenderer(JSONRenderer):
@@ -79,7 +79,7 @@ class JSONAPIRenderer(JSONRenderer):
         fields = {}
         if request:
             for key, value in six.iteritems(request.query_params):
-                m = RX_FIELDS.fullmatch(key)
+                m = RX_FIELDS.match(key)
                 if m:
                     fields[m.group(1)] = value.split(',')
         return fields

--- a/rest_framework_json_schema/renderers.py
+++ b/rest_framework_json_schema/renderers.py
@@ -14,7 +14,7 @@ class JSONAPIRenderer(JSONRenderer):
     jsonapi = None
 
     def render_obj(self, obj, schema, renderer_context, include):
-        return schema.render(obj, renderer_context.get('request', None), include)
+        return schema.render(obj, renderer_context.get('request', None), include, {})
 
     def render_list(self, obj_list, schema, renderer_context, include):
         primary = []

--- a/rest_framework_json_schema/schema.py
+++ b/rest_framework_json_schema/schema.py
@@ -6,13 +6,23 @@ from .exceptions import TypeConflict, IncludeInvalid
 from .transforms import NullTransform
 
 
+class Context(object):
+    """
+    Collection of arguments needed for rendering/parsing.
+    """
+    def __init__(self, request, include=None, fields=None):
+        self.request = request
+        self.include = include or {}
+        self.fields = fields or {}
+
+
 class BaseLinkedObject(object):
-    def render_links(self, data, request):
+    def render_links(self, data, context):
         return OrderedDict(
-            (link_name, link_obj.render(data, request)) for (link_name, link_obj) in self.links
+            (link_name, link_obj.render(data, context.request)) for (link_name, link_obj) in self.links
         )
 
-    def render_meta(self, data, request):
+    def render_meta(self, data, context):
         """
         Implement this in your subclass if you have more complex meta information
         that depends on data or the request.
@@ -53,7 +63,7 @@ class ResourceObject(BaseLinkedObject):
         for (name, rel) in self.relationships:
             self.transformed_names[name] = transformer.transform(name)
 
-    def parse(self, data, request):
+    def parse(self, data, context):
         """
         Parses a Resource Object representation into an internal representation.
         Verifies that the object is of the correct type.
@@ -73,7 +83,7 @@ class ResourceObject(BaseLinkedObject):
             })
         return result
 
-    def render(self, data, request, include, fields):
+    def render(self, data, context):
         """
         Renders data to a Resource Object representation.
         """
@@ -81,53 +91,57 @@ class ResourceObject(BaseLinkedObject):
             ('id', str(data[self.id])),
             ('type', self.type)
         ))
-        attributes = self.render_attributes(data, request, fields)
+        attributes = self.render_attributes(data, context)
         if attributes:
             result['attributes'] = attributes
 
-        relationships, included = self.render_relationships(data, request, include, fields)
+        relationships, included = self.render_relationships(data, context)
         if relationships:
             result['relationships'] = relationships
 
-        links = self.render_links(data, request)
+        links = self.render_links(data, context)
         if links:
             result['links'] = links
 
-        meta = self.render_meta(data, request)
+        meta = self.render_meta(data, context)
         if meta:
             result['meta'] = meta
         return result, included
 
-    def render_attributes(self, data, request, fields):
-        attributes = self.filter_by_fields(self.attributes, fields)
+    def render_attributes(self, data, context):
+        attributes = self.filter_by_fields(self.attributes, context.fields)
         return OrderedDict(
             (self.transformed_names[attr], self.from_data(data, attr)) for attr in attributes
         )
 
-    def render_relationships(self, data, request, include, fields):
+    def render_relationships(self, data, context):
         relationships = OrderedDict()
         included = []
         # Validate that all top-level include keys are actually relationships
         rel_keys = {rel[0] for rel in self.relationships}
-        for key in include:
+        for key in context.include:
             if key not in rel_keys:
                 raise IncludeInvalid('Invalid relationship to include: %s' % key)
 
-        filtered = self.filter_by_fields(self.relationships, fields, lambda x: x[0])
+        filtered = self.filter_by_fields(self.relationships, context.fields, lambda x: x[0])
         for (name, rel) in filtered:
-            relationship, rel_included = self.render_relationship(data, name, rel, request, include, fields)
+            relationship, rel_included = self.render_relationship(data, name, rel, context)
             relationships[self.transformed_names[name]] = relationship
             included.extend(rel_included)
 
         return relationships, included
 
-    def render_relationship(self, data, rel_name, rel, request, include, fields):
+    def render_relationship(self, data, rel_name, rel, context):
         # This relationship is included if rel_name is in the include paths.
-        include_this = rel_name in include
-        include_paths = include.get(rel_name, {})
-
+        include_this = rel_name in context.include
+        # Create a new context by going one level deeper into the include paths.
+        rel_context = Context(
+            context.request,
+            context.include.get(rel_name, {}),
+            context.fields
+        )
         rel_data = self.from_data(data, rel_name)
-        return rel.render(data, rel_data, request, include_this, include_paths, fields)
+        return rel.render(data, rel_data, rel_context, include_this)
 
     def from_data(self, data, attr):
         # This is easy for now, but eventually we want to be able to specify
@@ -191,13 +205,13 @@ class RelationshipObject(BaseLinkedObject):
         for key, value in kwargs.items():
             setattr(self, key, value)
 
-    def render_included(self, rel_data, request, include_paths, fields):
+    def render_included(self, rel_data, context):
         # This recursively calls the resource's schema to render the full object.
         schema = rel_data.get_schema()
-        obj, included = schema.render(rel_data.get_data(), request, include_paths, fields)
+        obj, included = schema.render(rel_data.get_data(), context)
         return [obj] + included
 
-    def render(self, obj_data, rel_data, request, include_this, include_paths, fields):
+    def render(self, obj_data, rel_data, context, include_this):
         result = OrderedDict()
         included = []
 
@@ -205,24 +219,24 @@ class RelationshipObject(BaseLinkedObject):
             # None or []
             result['data'] = rel_data
         elif isinstance(rel_data, ResourceIdObject):
-            result['data'] = rel_data.render(request)
+            result['data'] = rel_data.render(context.request)
             if include_this:
-                included.extend(self.render_included(rel_data, request, include_paths, fields))
+                included.extend(self.render_included(rel_data, context))
         else:
             # Probably a list of resource objects
             if include_this:
                 result['data'] = []
                 for obj in rel_data:
-                    result['data'].append(obj.render(request))
-                    included.extend(self.render_included(obj, request, include_paths, fields))
+                    result['data'].append(obj.render(context.request))
+                    included.extend(self.render_included(obj, context))
             else:
-                result['data'] = [obj.render(request) for obj in rel_data]
+                result['data'] = [obj.render(context.request) for obj in rel_data]
 
-        links = self.render_links(obj_data, request)
+        links = self.render_links(obj_data, context)
         if links:
             result['links'] = links
 
-        meta = self.render_meta(obj_data, request)
+        meta = self.render_meta(obj_data, context)
         if meta:
             result['meta'] = meta
         return result, included

--- a/rest_framework_json_schema/schema.py
+++ b/rest_framework_json_schema/schema.py
@@ -19,7 +19,8 @@ class Context(object):
 class BaseLinkedObject(object):
     def render_links(self, data, context):
         return OrderedDict(
-            (link_name, link_obj.render(data, context.request)) for (link_name, link_obj) in self.links
+            (link_name, link_obj.render(data, context.request))
+            for (link_name, link_obj) in self.links
         )
 
     def render_meta(self, data, context):

--- a/rest_framework_json_schema/tests/test_renderers.py
+++ b/rest_framework_json_schema/tests/test_renderers.py
@@ -106,6 +106,22 @@ class JSONAPIAttributesRendererTestCase(APISimpleTestCase):
             }
         })
 
+    def test_fields(self):
+        url = reverse('artist-detail', kwargs={'pk': 1})
+        request = self.factory.get(url, {'fields[artist]': 'firstName'})
+        response = self.view_detail(request, pk=1)
+        response.render()
+        self.assertEqual(response['Content-Type'], 'application/vnd.api+json')
+        self.assertJSONEqual(response.content.decode(), {
+            'data': {
+                'id': '1',
+                'type': 'artist',
+                'attributes': {
+                    'firstName': 'John',
+                }
+            }
+        })
+
 
 @override_settings(ROOT_URLCONF='rest_framework_json_schema.test_support.urls')
 class JSONAPIRelationshipsRendererTestCase(APISimpleTestCase):
@@ -340,6 +356,35 @@ class JSONAPIRelationshipsRendererTestCase(APISimpleTestCase):
                         'album': {
                             'data': {'id': '1', 'type': 'album'}
                         }
+                    }
+                }
+            ]
+        })
+
+    def test_fields(self):
+        request = self.factory.get(reverse('album-detail', kwargs={'pk': 0}),
+                                   {'fields[album]': 'artist',
+                                    'fields[artist]': 'firstName',
+                                    'include': 'artist'})
+        response = self.view_detail(request, pk=0)
+        response.render()
+        self.assertEqual(response['Content-Type'], 'application/vnd.api+json')
+        self.assertJSONEqual(response.content.decode(), {
+            'data': {
+                'id': '0',
+                'type': 'album',
+                'relationships': {
+                    'artist': {
+                        'data': {'id': '1', 'type': 'artist'}
+                    }
+                }
+            },
+            'included': [
+                {
+                    'id': '1',
+                    'type': 'artist',
+                    'attributes': {
+                        'firstName': 'John'
                     }
                 }
             ]

--- a/rest_framework_json_schema/tests/test_schema.py
+++ b/rest_framework_json_schema/tests/test_schema.py
@@ -4,7 +4,8 @@ from django.test import SimpleTestCase, override_settings
 from rest_framework.test import APIRequestFactory
 
 from rest_framework_json_schema.exceptions import TypeConflict, IncludeInvalid
-from rest_framework_json_schema.schema import (ResourceObject, RelationshipObject,
+from rest_framework_json_schema.schema import (Context,
+                                               ResourceObject, RelationshipObject,
                                                ResourceIdObject, LinkObject, UrlLink)
 from rest_framework_json_schema.transforms import CamelCaseTransform
 from rest_framework_json_schema.utils import parse_include
@@ -23,7 +24,7 @@ class ResourceObjectTest(SimpleTestCase):
         primary, included = ResourceObject().render({
             'id': '123',
             'attribute': 'ignored'
-        }, self.request, {}, {})
+        }, Context(self.request))
         self.assertEqual(primary, OrderedDict((
             ('id', '123'),
             ('type', 'unknown')
@@ -38,7 +39,7 @@ class ResourceObjectTest(SimpleTestCase):
         primary, included = obj.render({
             'user_id': '123',
             'name': 'John'
-        }, self.request, {}, {})
+        }, Context(self.request))
         self.assertEqual(primary, OrderedDict((
             ('id', '123'),
             ('type', 'users'),
@@ -58,7 +59,7 @@ class ResourceObjectTest(SimpleTestCase):
         primary, included = TestObject().render({
             'user_id': '123',
             'name': 'John'
-        }, self.request, {}, {})
+        }, Context(self.request))
         self.assertEqual(primary, OrderedDict((
             ('id', '123'),
             ('type', 'users'),
@@ -90,7 +91,7 @@ class ResourceObjectTest(SimpleTestCase):
                 ('object', ObjectLink())
             )
 
-        primary, included = TestObject().render({'id': '123'}, self.request, {}, {})
+        primary, included = TestObject().render({'id': '123'}, Context(self.request))
         self.assertEqual(primary, OrderedDict((
             ('id', '123'),
             ('type', 'artists'),
@@ -109,7 +110,7 @@ class ResourceObjectTest(SimpleTestCase):
         An optional meta object is rendered
         """
         obj = ResourceObject(type='users', meta={'foo': 'bar'})
-        primary, included = obj.render({'id': '123'}, self.request, {}, {})
+        primary, included = obj.render({'id': '123'}, Context(self.request))
         self.assertEqual(primary, OrderedDict((
             ('id', '123'),
             ('type', 'users'),
@@ -131,7 +132,7 @@ class ResourceObjectTest(SimpleTestCase):
         # To-Many: an array of ResourceIdObjects
         obj = AlbumObject()
 
-        primary, included = obj.render({'id': '123', 'artist': None}, self.request, {}, {})
+        primary, included = obj.render({'id': '123', 'artist': None}, Context(self.request))
         self.assertEqual(primary, OrderedDict((
             ('id', '123'),
             ('type', 'album'),
@@ -141,7 +142,7 @@ class ResourceObjectTest(SimpleTestCase):
         )))
         self.assertEqual(included, [])
 
-        primary, included = obj.render({'id': '123', 'artist': []}, self.request, {}, {})
+        primary, included = obj.render({'id': '123', 'artist': []}, Context(self.request))
         self.assertEqual(primary, OrderedDict((
             ('id', '123'),
             ('type', 'album'),
@@ -154,7 +155,7 @@ class ResourceObjectTest(SimpleTestCase):
         primary, included = obj.render({
             'id': '123',
             'artist': ResourceIdObject(id=5, type='artist')
-        }, self.request, {}, {})
+        }, Context(self.request))
         self.assertEqual(primary, OrderedDict((
             ('id', '123'),
             ('type', 'album'),
@@ -172,7 +173,7 @@ class ResourceObjectTest(SimpleTestCase):
                 ResourceIdObject(id=5, type='artist'),
                 ResourceIdObject(id=6, type='artist')
             ]
-        }, self.request, {}, {})
+        }, Context(self.request))
         self.assertEqual(primary, OrderedDict((
             ('id', '123'),
             ('type', 'album'),
@@ -209,7 +210,7 @@ class ResourceObjectTest(SimpleTestCase):
 
         obj = AlbumObject()
 
-        primary, included = obj.render({'id': '123', 'album_artist': None}, self.request, {}, {})
+        primary, included = obj.render({'id': '123', 'album_artist': None}, Context(self.request))
         self.assertEqual(primary, OrderedDict((
             ('id', '123'),
             ('type', 'album'),
@@ -254,7 +255,7 @@ class ResourceObjectTest(SimpleTestCase):
         primary, included = AlbumObject().render({
             'id': '123',
             'artist': ArtistLink(id=5, type='artist')
-        }, self.request, parse_include('artist'), {})
+        }, Context(self.request, parse_include('artist')))
         self.assertEqual(included, [
             OrderedDict((
                 ('id', '5'),
@@ -316,7 +317,7 @@ class ResourceObjectTest(SimpleTestCase):
             'first_name': 'John',
             'last_name': 'Coltrane',
             'albums': [AlbumLink(id=5, name='A Love Supreme')]
-        }, self.request, parse_include('albums.tracks'), {})
+        }, Context(self.request, parse_include('albums.tracks')))
         self.assertEqual(included, [
             OrderedDict((
                 ('id', '5'),
@@ -364,7 +365,7 @@ class ResourceObjectTest(SimpleTestCase):
                 'first_name': 'John',
                 'last_name': 'Coltrane',
                 'albums': []
-            }, self.request, parse_include('invalid'), {})
+            }, Context(self.request, parse_include('invalid')))
 
     def test_render_sparse_fields(self):
         """
@@ -399,7 +400,8 @@ class ResourceObjectTest(SimpleTestCase):
             'artist': ArtistLink(id=5, type='artist')
         }
 
-        primary, included = AlbumObject().render(obj, self.request, {}, {'album': ['name']})
+        context = Context(self.request, fields={'album': ['name']})
+        primary, included = AlbumObject().render(obj, context)
 
         self.assertEqual(primary, OrderedDict((
             ('id', '123'),
@@ -411,7 +413,8 @@ class ResourceObjectTest(SimpleTestCase):
         self.assertEqual(included, [])
 
         # Sparse relationship
-        primary, included = AlbumObject().render(obj, self.request, {}, {'album': ['artist']})
+        context = Context(self.request, fields={'album': ['artist']})
+        primary, included = AlbumObject().render(obj, context)
         self.assertEqual(primary, OrderedDict((
             ('id', '123'),
             ('type', 'album'),
@@ -423,9 +426,12 @@ class ResourceObjectTest(SimpleTestCase):
         )))
 
         # Include a relationship with sparse fields specified for that relationship
-        primary, included = AlbumObject().render(obj, self.request,
-                                                 parse_include('artist'),
-                                                 {'artist': ['first_name']})
+        context = Context(
+            self.request,
+            parse_include('artist'),
+            {'artist': ['first_name']}
+        )
+        primary, included = AlbumObject().render(obj, context)
         self.assertEqual(included, [
             OrderedDict((
                 ('id', '5'),
@@ -471,7 +477,8 @@ class ResourceObjectTest(SimpleTestCase):
             'genre': 'Jazz',
             'artist': ArtistLink(id=5, type='artist')
         }
-        primary, included = AlbumObject().render(obj, self.request, {}, {'album': ['albumName']})
+        context = Context(self.request, fields={'album': ['albumName']})
+        primary, included = AlbumObject().render(obj, context)
 
         self.assertEqual(primary, OrderedDict((
             ('id', '123'),
@@ -491,7 +498,7 @@ class ResourceObjectTest(SimpleTestCase):
             'id': '123',
             'first_name': 'John',
             'last_name': 'Coltrane'
-        }, self.request, {}, {})
+        }, Context(self.request))
         self.assertEqual(primary, OrderedDict((
             ('id', '123'),
             ('type', 'users'),
@@ -515,7 +522,7 @@ class ResourceObjectTest(SimpleTestCase):
                 'firstName': 'John',
                 'lastName': 'Coltrane'
             }
-        }, self.request)
+        }, Context(self.request))
         self.assertEqual(result, {
             'id': '123',
             'first_name': 'John',
@@ -533,7 +540,7 @@ class ResourceObjectTest(SimpleTestCase):
             'attributes': {
                 'firstName': 'John'
             }
-        }, self.request)
+        }, Context(self.request))
         self.assertEqual(result, {
             'first_name': 'John'
         })
@@ -547,6 +554,6 @@ class ResourceObjectTest(SimpleTestCase):
             obj.parse({
                 'id': '123',
                 'type': 'something'
-            }, self.request)
+            }, Context(self.request))
         with self.assertRaises(TypeConflict):
             obj.parse({}, self.request)


### PR DESCRIPTION
Support for the `fields[type]=a,b,c` query parameter.

This merely stops the fields from appearing in the rendered output: not retrieving these fields from the underlying storage is left to the upper layers, since we don't know how the data is getting to the schema.

