### PR TITLE
Parse relationships and support DRF 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
   - DJANGO='django>=1.11.0,<1.12.0' DRF='djangorestframework>=3.5,<3.6'
   - DJANGO='django>=1.10.0,<1.11.0' DRF='djangorestframework>=3.6,<3.7'
   - DJANGO='django>=1.11.0,<1.12.0' DRF='djangorestframework>=3.6,<3.7'
+  - DJANGO='django>=1.10.0,<1.11.0' DRF='djangorestframework>=3.7,<3.8'
+  - DJANGO='django>=1.11.0,<1.12.0' DRF='djangorestframework>=3.7,<3.8'
 before_install:
   - pip install -U pytest
   - pip install -r requirements-test.txt

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
+six
 pytest
 pytest-cov
 pytest-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django>=1.8
 djangorestframework>=3.5
-
+six

--- a/rest_framework_json_schema/schema.py
+++ b/rest_framework_json_schema/schema.py
@@ -82,6 +82,13 @@ class ResourceObject(BaseLinkedObject):
                 attr: attributes[self.transformed_names[attr]]
                 for attr in self.attributes if self.transformed_names[attr] in attributes
             })
+        relationships = data.get('relationships')
+        if relationships:
+            result.update({
+                name: rel.parse(relationships[self.transformed_names[name]], context)
+                for (name, rel) in self.relationships
+                if self.transformed_names[name] in relationships
+            })
         return result
 
     def render(self, data, context):
@@ -241,6 +248,15 @@ class RelationshipObject(BaseLinkedObject):
         if meta:
             result['meta'] = meta
         return result, included
+
+    def parse(self, obj_data, context):
+        # Unless the Schema provides it, there's no way to verify the type
+        # of the relationship. So we just look for the ID and propagate it.
+        data = obj_data.get('data')
+        if isinstance(data, list):
+            return [obj['id'] for obj in data]
+        elif isinstance(data, dict):
+            return data['id']
 
 
 class LinkObject(object):

--- a/rest_framework_json_schema/tests/test_parsers.py
+++ b/rest_framework_json_schema/tests/test_parsers.py
@@ -2,8 +2,9 @@ from django.core.urlresolvers import reverse
 from django.test import override_settings
 from rest_framework.test import APISimpleTestCase, APIRequestFactory
 
-from rest_framework_json_schema.test_support.serializers import reset_data, get_artists
-from rest_framework_json_schema.test_support.views import ArtistViewSet
+from rest_framework_json_schema.test_support.serializers import (
+    reset_data, get_artists, get_albums, get_tracks)
+from rest_framework_json_schema.test_support.views import ArtistViewSet, AlbumViewSet
 
 
 @override_settings(ROOT_URLCONF='rest_framework_json_schema.test_support.urls')
@@ -43,7 +44,7 @@ class JSONAPIParserTestCase(APISimpleTestCase):
                 }
             }
         })
-        artist = get_artists()[1]
+        artist = get_artists().get(1)
         self.assertEqual(artist.id, 1)
         self.assertEqual(artist.first_name, 'Art')
         self.assertEqual(artist.last_name, 'Blakey')
@@ -74,7 +75,65 @@ class JSONAPIParserTestCase(APISimpleTestCase):
                 }
             }
         })
-        artist = get_artists()[6]
+        artist = get_artists().get(6)
         self.assertEqual(artist.id, 6)
         self.assertEqual(artist.first_name, 'Thelonious')
         self.assertEqual(artist.last_name, 'Monk')
+
+    def test_relationships(self):
+        """
+        You can parse relationships.
+        """
+        album_list = AlbumViewSet.as_view({'post': 'create'})
+        artist = get_artists().get(0)
+        track = get_tracks().get(0)
+        request = self.factory.post(reverse('album-list'), {
+            'data': {
+                'type': 'album',
+                'attributes': {
+                    'albumName': 'On the Corner'
+                },
+                'relationships': {
+                    'artist': {
+                        'data': {
+                            'id': artist.id,
+                            'type': 'artist'
+                        }
+                    },
+                    'tracks': {
+                        'data': [{
+                            'id': track.id,
+                            'type': 'track'
+                        }]
+                    }
+                }
+            }
+        })
+        response = album_list(request)
+        response.render()
+        self.assertEqual(response['Content-Type'], 'application/vnd.api+json')
+        self.assertJSONEqual(response.content.decode(), {
+            'data': {
+                'id': '4',
+                'type': 'album',
+                'attributes': {
+                    'albumName': 'On the Corner'
+                },
+                'relationships': {
+                    'artist': {
+                        'data': {
+                            'id': str(artist.id),
+                            'type': 'artist'
+                        }
+                    },
+                    'tracks': {
+                        'data': [
+                            {'id': '0', 'type': 'track'}
+                        ]
+                    }
+                }
+            }
+        })
+        album = get_albums()[4]
+        self.assertEqual(album.album_name, 'On the Corner')
+        self.assertEqual(album.artist.id, artist.id)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36}-{django110,django111}-drf{35,36}
+    {py27,py34,py35,py36}-{django110,django111}-drf{35,36,37}
 
 [testenv]
 deps =
@@ -9,4 +9,5 @@ deps =
     django111: django>=1.11.0,<1.12.0
     drf35: djangorestframework>=3.5.<3.6
     drf36: djangorestframework>=3.6.<3.7
+    drf37: djangorestframework>=3.7.<3.8
 commands = py.test --flake8


### PR DESCRIPTION
1. We hadn't ever supported parsing relationships. Now we do.
2. Add DRF 3.7 to the test matrix.