### PR TITLE
Add the ability to generate a schema from a DRF serializer

### DIFF
--- a/rest_framework_json_schema/auto.py
+++ b/rest_framework_json_schema/auto.py
@@ -1,0 +1,122 @@
+"""Generate schemas from DRF serializers."""
+
+from typing import Any, Dict, Type, TypeVar, Generic, List, Optional
+
+from rest_framework import serializers
+
+from .schema import ResourceObject
+
+T = TypeVar("T", bound=serializers.Serializer)
+
+
+def from_serializer(
+    serializer: serializers.Serializer,
+    api_type: str,
+    *,
+    id_field: str = "",
+    **kwargs: Any,
+) -> Type[ResourceObject]:
+    """
+    Generate a schema from a DRF serializer.
+
+    :param serializer: The serializer instance.
+    :param api_type: The JSON API resource type.
+    :param id_field: The 'id" field of the resource.
+        If left empty, it is either "id" for non-model serializers, or
+        for model serializers, it is looked up on the model.
+    :param kwargs: Extra options (like links and transforms) passed to the schema.
+    :return: The new schema class.
+    """
+
+    # get_fields() should return them in the order of Meta.fields
+    serializer_name = type(serializer).__name__
+
+    attrs: List[str] = []
+    rels: List[str] = []
+
+    if not id_field:
+        # If this is a model serializer, we can reach in to the model
+        # and look for the model's PK.
+        if isinstance(serializer, serializers.ModelSerializer):
+            model = serializer.Meta.model
+            for db_field in model._meta.get_fields():
+                if db_field.primary_key:
+                    id_field = db_field.attname
+                    break
+
+            if not id_field:
+                raise ValueError(f"Unable to find primary key from model: {model}")
+        else:
+            # Otherwise, just assume it's "id"
+            id_field = "id"
+
+    for field_name, field in serializer.get_fields().items():
+        if field_name != id_field:
+            if isinstance(field, serializers.RelatedField):
+                rels.append(field_name)
+            else:
+                attrs.append(field_name)
+
+    values: Dict[str, Any] = {
+        "id": id_field,
+        "type": api_type,
+        "attributes": attrs,
+        "relationships": rels,
+    }
+    values.update(**kwargs)
+    return type(f"{serializer_name}_AutoSchema", (ResourceObject,), values)
+
+
+class AutoSchemaDescriptor(Generic[T]):
+    """Descriptor used to implement auto_schema."""
+
+    def __init__(
+        self, api_type: str, id_field: str, init_kwargs: Dict[str, Any]
+    ) -> None:
+        """Create the descriptor."""
+        self.api_type = api_type
+        self.id_field = id_field
+        self.init_kwargs = init_kwargs
+        self._cached: Optional[Type[ResourceObject]] = None
+
+    def __get__(self, serializer: T, objtype: Type[T]) -> Type[ResourceObject]:
+        """Generate the serializer."""
+        if not self._cached:
+            self._cached = from_serializer(
+                serializer, self.api_type, id_field=self.id_field, **self.init_kwargs
+            )
+        return self._cached
+
+
+def auto_schema(
+    api_type: str, *, id_field: str = "", **kwargs: Any
+) -> AutoSchemaDescriptor:
+    """
+    Generate a schema from this serializer.
+
+    Usage:
+        ``
+        from rest_framework_json_schema.auto import auto_schema
+
+        class ArtistSerializer:
+            schema = auto_schema("artists")
+        ``
+
+    You can create a wrapper function to provide defaults:
+
+        ``
+        from rest_framework_json_schema.auto import auto_schema
+        from rest_framework_json_schema.transforms import CamelCaseTransform
+
+        def my_auto_schema(*args, **kwargs):
+            return auto_schema(*args, **kwargs, transform=CamelCaseTransform)
+        ``
+
+    :param api_type: The JSON API resource type.
+    :param id_field: The 'id" field of the resource.
+        If left empty, it is either "id" for non-model serializers, or
+        for model serializers, it is looked up on the model.
+    :param kwargs: Extra options (like links and transforms) passed to the schema.
+    :return: The new schema class.
+    """
+    return AutoSchemaDescriptor(api_type, id_field, kwargs)

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -1,0 +1,125 @@
+from django.db import models
+from rest_framework import serializers
+
+from rest_framework_json_schema.auto import from_serializer, auto_schema
+from rest_framework_json_schema.schema import ResourceObject
+from rest_framework_json_schema.transforms import CamelCaseTransform
+
+
+class MyModel(models.Model):
+    my_int = models.IntegerField()
+    my_str = models.CharField()
+
+    class Meta:
+        app_label = "auto_test"
+
+
+class RelModel(models.Model):
+    my_rel = models.ForeignKey(MyModel, on_delete=models.CASCADE)
+    int_rel = models.IntegerField()
+
+    class Meta:
+        app_label = "auto_test"
+
+
+class NonIdModel(models.Model):
+    my_id = models.AutoField(primary_key=True)
+    my_int = models.IntegerField()
+
+    class Meta:
+        app_label = "auto_test"
+
+
+def test_from_serializer() -> None:
+    """Basic creation of a schema."""
+
+    class MySerializer(serializers.Serializer):
+        id = serializers.IntegerField()
+        int_attr = serializers.IntegerField()
+        my_attr = serializers.CharField()
+
+    result = from_serializer(MySerializer(), "mytype")
+    assert isinstance(result, type(ResourceObject))
+    assert result.type == "mytype"
+    assert result.id == "id"
+    assert result.attributes == ["int_attr", "my_attr"]
+    assert result.relationships == []
+
+
+def test_from_model_serializer() -> None:
+    """Given a model serializer, it respects the order of Meta.fields."""
+
+    class MySerializer(serializers.ModelSerializer):
+        class Meta:
+            model = MyModel
+            fields = ["id", "my_str", "my_int"]
+
+    result = from_serializer(MySerializer(), "mymodel")
+    assert isinstance(result, type(ResourceObject))
+    assert result.type == "mymodel"
+    assert result.id == "id"
+    assert result.attributes == ["my_str", "my_int"]
+    assert result.relationships == []
+
+
+def test_model_relations() -> None:
+    """Given a model serializer, it adds relationships."""
+
+    class MySerializer(serializers.ModelSerializer):
+        class Meta:
+            model = RelModel
+            fields = ["id", "int_rel", "my_rel"]
+
+    result = from_serializer(MySerializer(), "myrel")
+    assert isinstance(result, type(ResourceObject))
+    assert result.type == "myrel"
+    assert result.id == "id"
+    assert result.attributes == ["int_rel"]
+    assert result.relationships == ["my_rel"]
+
+
+def test_non_id_primary() -> None:
+    """Test where a model has a pk not named "id"."""
+
+    class NonIdSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = NonIdModel
+            fields = ["my_id", "my_int"]
+
+    result = from_serializer(NonIdSerializer(), "nonid")
+    assert isinstance(result, type(ResourceObject))
+    assert result.type == "nonid"
+    assert result.id == "my_id"
+    assert result.attributes == ["my_int"]
+    assert result.relationships == []
+
+
+def test_extra_params() -> None:
+    """Extra parameters are passed along to the schema."""
+
+    class MySerializer(serializers.Serializer):
+        id = serializers.IntegerField()
+        my_attr = serializers.CharField()
+
+    result = from_serializer(MySerializer(), "mytype", transformer=CamelCaseTransform)
+    assert isinstance(result, type(ResourceObject))
+    assert result.transformer == CamelCaseTransform
+
+
+def test_descriptor() -> None:
+    """You can use the auto_schema descriptor."""
+
+    class MySerializer(serializers.Serializer):
+        id = serializers.IntegerField()
+        my_attr = serializers.CharField()
+
+        schema = auto_schema("mytype", transformer=CamelCaseTransform)
+
+    serializer = MySerializer()
+    result = serializer.schema()
+    assert isinstance(result, ResourceObject)
+    assert result.type == "mytype"
+    assert result.id == "id"
+    assert result.attributes == ["my_attr"]
+    assert result.relationships == []
+    assert result.transformer == CamelCaseTransform

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -39,7 +39,7 @@ def test_from_serializer() -> None:
         my_attr = serializers.CharField()
 
     result = from_serializer(MySerializer(), "mytype")
-    assert isinstance(result, type(ResourceObject))
+    assert issubclass(result, ResourceObject)
     assert result.type == "mytype"
     assert result.id == "id"
     assert result.attributes == ["int_attr", "my_attr"]
@@ -55,7 +55,7 @@ def test_from_model_serializer() -> None:
             fields = ["id", "my_str", "my_int"]
 
     result = from_serializer(MySerializer(), "mymodel")
-    assert isinstance(result, type(ResourceObject))
+    assert issubclass(result, ResourceObject)
     assert result.type == "mymodel"
     assert result.id == "id"
     assert result.attributes == ["my_str", "my_int"]
@@ -71,7 +71,7 @@ def test_model_relations() -> None:
             fields = ["id", "int_rel", "my_rel"]
 
     result = from_serializer(MySerializer(), "myrel")
-    assert isinstance(result, type(ResourceObject))
+    assert issubclass(result, ResourceObject)
     assert result.type == "myrel"
     assert result.id == "id"
     assert result.attributes == ["int_rel"]
@@ -87,7 +87,7 @@ def test_non_id_primary() -> None:
             fields = ["my_id", "my_int"]
 
     result = from_serializer(NonIdSerializer(), "nonid")
-    assert isinstance(result, type(ResourceObject))
+    assert issubclass(result, ResourceObject)
     assert result.type == "nonid"
     assert result.id == "my_id"
     assert result.attributes == ["my_int"]
@@ -102,7 +102,7 @@ def test_extra_params() -> None:
         my_attr = serializers.CharField()
 
     result = from_serializer(MySerializer(), "mytype", transformer=CamelCaseTransform)
-    assert isinstance(result, type(ResourceObject))
+    assert issubclass(result, ResourceObject)
     assert result.transformer == CamelCaseTransform
 
 


### PR DESCRIPTION
This is a rather long time coming, but it's here. You can how use `auto_schema` to generate a ResourceObject/schema from a DRF serializer.

We attempt to get the attributes/relationships from the field types.

This isn't meant to work in *every* circumstance -- there are certainly cases where you will need to define your own schema. But for many simple cases, this should save writing your own serializer.

It also allows currying mechanism to provide defaults to schema.