### PR TITLE
Fix getting primary_key

### DIFF
--- a/rest_framework_json_schema/auto.py
+++ b/rest_framework_json_schema/auto.py
@@ -40,7 +40,7 @@ def from_serializer(
         if isinstance(serializer, serializers.ModelSerializer):
             model = serializer.Meta.model
             for db_field in model._meta.get_fields():
-                if db_field.primary_key:
+                if getattr(db_field, "primary_key", False):
                     id_field = db_field.attname
                     break
 


### PR DESCRIPTION
In certain circumstances a field may not have a primary_key field.
I think this happens with reverse relationships -- like ManyToOneRel
or OneToOneRel. Because of the way the tests don't use "real" models,
Django doesn't set up these reverse relationships so it's difficult
to test right now.