### PR TITLE
Support object creation with a non-default ID

### DIFF
--- a/rest_framework_json_schema/schema.py
+++ b/rest_framework_json_schema/schema.py
@@ -123,7 +123,7 @@ class ResourceObject(BaseLinkedObject):
         result: OrderedDict = OrderedDict()
         id = data.get("id")
         if id:
-            result["id"] = id
+            result[self.id] = id
         attributes = data.get("attributes")
         if attributes:
             result.update(

--- a/tests/support/serializers.py
+++ b/tests/support/serializers.py
@@ -84,6 +84,23 @@ class Track(BaseModel):
         self.album = album
 
 
+class NonDefaultId:
+    """An object with a non default ID."""
+
+    non_default_id: str
+    name: str
+
+    def __init__(self, non_default_id: str, name: str) -> None:
+        """Create the object."""
+        self.non_default_id = non_default_id
+        self.name = name
+
+    @property
+    def pk(self) -> str:
+        """Return the model primary key."""
+        return self.non_default_id
+
+
 INITIAL_ARTISTS: List[Artist] = [
     Artist(0, "Miles", "Davis"),
     Artist(1, "John", "Coltrane"),
@@ -109,6 +126,7 @@ INITIAL_TRACKS: List[Track] = [
     Track(3, 4, "Deception", INITIAL_ALBUMS[1]),
 ]
 TRACKS: List[Track] = []
+NON_DEFAULT_IDS: List[NonDefaultId] = []
 
 
 T = TypeVar("T")
@@ -157,14 +175,21 @@ def get_tracks() -> QuerySet:
     return QuerySet(TRACKS)
 
 
+def get_non_default_ids() -> QuerySet:
+    """Get all tracks."""
+    return QuerySet(NON_DEFAULT_IDS)
+
+
 def reset_data() -> None:
     """Reset test data."""
     global ARTISTS
     global ALBUMS
     global TRACKS
+    global NON_DEFAULT_IDS
     ARTISTS = deepcopy(INITIAL_ARTISTS)
     ALBUMS = deepcopy(INITIAL_ALBUMS)
     TRACKS = deepcopy(INITIAL_TRACKS)
+    NON_DEFAULT_IDS = deepcopy(NON_DEFAULT_IDS)
 
 
 reset_data()
@@ -194,6 +219,14 @@ class TrackObject(ResourceObject):
     attributes = ("track_num", "name")
     relationships = ("album",)
     transformer = CamelCaseTransform
+
+
+class NonDefaultIdObject(ResourceObject):
+    """Resource object for non-default ID objects."""
+
+    type = "non-defaults"
+    id = "non_default_id"
+    attributes = ("name",)
 
 
 class ArtistSerializer(serializers.Serializer):
@@ -248,4 +281,18 @@ class AlbumSerializer(serializers.Serializer):
         """Create an album model."""
         validated_data["id"] = get_albums().count()
         get_albums().add(Album(**validated_data))
+        return validated_data
+
+
+class NonDefaultIdSerializer(serializers.Serializer):
+    """Serializer for non default IDs models."""
+
+    non_default_id = serializers.CharField()
+    name = serializers.CharField()
+
+    schema = NonDefaultIdObject
+
+    def create(self, validated_data: Dict) -> Dict:
+        """Create an album model."""
+        get_non_default_ids().add(NonDefaultId(**validated_data))
         return validated_data

--- a/tests/support/urls.py
+++ b/tests/support/urls.py
@@ -7,6 +7,7 @@ from .views import (
     TrackViewSet,
     PaginateViewSet,
     NonJSONPaginateViewSet,
+    NonDefaultIdViewSet,
 )
 
 router = routers.DefaultRouter()
@@ -15,5 +16,6 @@ router.register(r"album", AlbumViewSet, "album")
 router.register(r"track", TrackViewSet, "track")
 router.register(r"paged", PaginateViewSet, "page")
 router.register(r"paged-nonjson", NonJSONPaginateViewSet, "page-nonjson")
+router.register(r"non-default-id", NonDefaultIdViewSet, "non-default-id")
 
 urlpatterns = [url(r"^api/", include(router.urls))]

--- a/tests/support/views.py
+++ b/tests/support/views.py
@@ -16,13 +16,16 @@ from .serializers import (
     ArtistSerializer,
     AlbumSerializer,
     TrackSerializer,
+    NonDefaultIdSerializer,
     get_artists,
     get_albums,
     get_tracks,
+    get_non_default_ids,
     QuerySet,
     Artist,
     Album,
     Track,
+    NonDefaultId,
 )
 
 try:
@@ -118,3 +121,14 @@ class TrackViewSet(BaseViewSet):
     def get_queryset(self) -> QuerySet[Track]:
         """Return the list of tracks."""
         return get_tracks()
+
+
+class NonDefaultIdViewSet(BaseViewSet):
+    """A ViewSet to test non-default IDs."""
+
+    serializer_class = NonDefaultIdSerializer
+    pagination_class = None
+
+    def get_queryset(self) -> QuerySet[NonDefaultId]:
+        """Return the list of non default ID objects."""
+        return get_non_default_ids()

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -4,8 +4,13 @@ from django.urls import reverse
 from rest_framework.test import APIRequestFactory
 
 from tests.support.decorators import mark_urls
-from tests.support.serializers import get_artists, get_albums, get_tracks
-from tests.support.views import ArtistViewSet, AlbumViewSet
+from tests.support.serializers import (
+    get_artists,
+    get_albums,
+    get_tracks,
+    get_non_default_ids,
+)
+from tests.support.views import ArtistViewSet, AlbumViewSet, NonDefaultIdViewSet
 
 
 @mark_urls
@@ -103,3 +108,23 @@ def test_parse_relationships(factory: APIRequestFactory) -> None:
     album = get_albums()[4]
     assert album.album_name == "On the Corner"
     assert album.artist.id == artist.id
+
+
+@mark_urls
+def test_post_non_default_id(factory: APIRequestFactory) -> None:
+    """POSTing with a non-default ID works."""
+    non_default_list = NonDefaultIdViewSet.as_view({"post": "create"})
+    request = factory.post(
+        reverse("non-default-id-list"),
+        {
+            "data": {
+                "id": "foo",
+                "type": "non-defaults",
+                "attributes": {"name": "my name"},
+            }
+        },
+    )
+    response = non_default_list(request)
+    assert response.status_code == 201
+    models = get_non_default_ids()
+    assert models[0].non_default_id == "foo"


### PR DESCRIPTION
If an object had a non-default ID value, we weren't propagating that value to the correct name in the parsed data.

A lot of test code for a one line fix.